### PR TITLE
Photon Vision Updates

### DIFF
--- a/swerve/odometry/SwerveOdometry.java
+++ b/swerve/odometry/SwerveOdometry.java
@@ -1,12 +1,17 @@
 package frc.robot.ShamLib.swerve.odometry;
 
+import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
 import frc.robot.ShamLib.swerve.TimestampedPoseEstimator;
 import java.util.List;
 
 public interface SwerveOdometry {
+  public static record TimestampedVisionUpdate(
+          double timestamp, Pose2d pose, Matrix<N3, N1> stdDevs) {}
 
   public void resetPose(Pose2d newPose, SwerveModulePosition[] modulePositions);
 

--- a/swerve/odometry/SwerveOdometry.java
+++ b/swerve/odometry/SwerveOdometry.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public interface SwerveOdometry {
   public static record TimestampedVisionUpdate(
-          double timestamp, Pose2d pose, Matrix<N3, N1> stdDevs) {}
+      double timestamp, Pose2d pose, Matrix<N3, N1> stdDevs) {}
 
   public void resetPose(Pose2d newPose, SwerveModulePosition[] modulePositions);
 

--- a/swerve/odometry/SwerveOdometryReal.java
+++ b/swerve/odometry/SwerveOdometryReal.java
@@ -5,6 +5,9 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.wpilibj.Timer;
+import frc.robot.ShamLib.swerve.TimestampedPoseEstimator;
+
+import java.util.List;
 
 public class SwerveOdometryReal implements SwerveOdometry {
 
@@ -17,6 +20,14 @@ public class SwerveOdometryReal implements SwerveOdometry {
   @Override
   public void addVisionMeasurement(Pose2d pose) {
     odometry.addVisionMeasurement(getPose(), Timer.getFPGATimestamp());
+  }
+
+
+  @Override
+  public void addTimestampedVisionMeasurements(List<TimestampedPoseEstimator.TimestampedVisionUpdate> visionEstimates) {
+    for (var visionEstimate : visionEstimates) {
+      odometry.addVisionMeasurement(visionEstimate.pose(), visionEstimate.timestamp(), visionEstimate.stdDevs());
+    }
   }
 
   @Override

--- a/swerve/odometry/SwerveOdometryReal.java
+++ b/swerve/odometry/SwerveOdometryReal.java
@@ -6,7 +6,6 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.wpilibj.Timer;
 import frc.robot.ShamLib.swerve.TimestampedPoseEstimator;
-
 import java.util.List;
 
 public class SwerveOdometryReal implements SwerveOdometry {
@@ -22,11 +21,12 @@ public class SwerveOdometryReal implements SwerveOdometry {
     odometry.addVisionMeasurement(getPose(), Timer.getFPGATimestamp());
   }
 
-
   @Override
-  public void addTimestampedVisionMeasurements(List<TimestampedPoseEstimator.TimestampedVisionUpdate> visionEstimates) {
+  public void addTimestampedVisionMeasurements(
+      List<TimestampedPoseEstimator.TimestampedVisionUpdate> visionEstimates) {
     for (var visionEstimate : visionEstimates) {
-      odometry.addVisionMeasurement(visionEstimate.pose(), visionEstimate.timestamp(), visionEstimate.stdDevs());
+      odometry.addVisionMeasurement(
+          visionEstimate.pose(), visionEstimate.timestamp(), visionEstimate.stdDevs());
     }
   }
 

--- a/vision/PhotonVision/Apriltag/PVApriltagCam.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagCam.java
@@ -4,15 +4,11 @@ import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import frc.robot.ShamLib.ShamLibConstants;
 import frc.robot.ShamLib.swerve.TimestampedPoseEstimator;
-import frc.robot.ShamLib.util.GeomUtil;
-import java.util.ArrayList;
-import java.util.Optional;
 import org.littletonrobotics.junction.Logger;
 import org.photonvision.PhotonPoseEstimator;
 
@@ -23,7 +19,10 @@ public class PVApriltagCam {
   private final AprilTagFieldLayout fieldLayout;
 
   public PVApriltagCam(
-      String name, ShamLibConstants.BuildMode buildMode, Transform3d botToCam, AprilTagFieldLayout fieldLayout) {
+      String name,
+      ShamLibConstants.BuildMode buildMode,
+      Transform3d botToCam,
+      AprilTagFieldLayout fieldLayout) {
     io = getNewIO(buildMode, name, botToCam, fieldLayout);
     this.name = name;
     this.fieldLayout = fieldLayout;
@@ -62,7 +61,8 @@ public class PVApriltagCam {
       var tagOnField = fieldLayout.getTagPose(tagId);
 
       if (tagOnField.isPresent()) {
-        totalDistance += pose.getTranslation().getDistance(tagOnField.get().toPose2d().getTranslation());
+        totalDistance +=
+            pose.getTranslation().getDistance(tagOnField.get().toPose2d().getTranslation());
         nonErrorTags++;
       }
     }
@@ -80,13 +80,16 @@ public class PVApriltagCam {
 
   public TimestampedPoseEstimator.TimestampedVisionUpdate getLatestEstimate() {
     return new TimestampedPoseEstimator.TimestampedVisionUpdate(
-            inputs.timestamp,
-            inputs.poseEstimate,
-            getXYThetaStdDev(inputs.poseEstimate, inputs.targetsUsed)
-    );
+        inputs.timestamp,
+        inputs.poseEstimate,
+        getXYThetaStdDev(inputs.poseEstimate, inputs.targetsUsed));
   }
 
-  private PVApriltagIO getNewIO(ShamLibConstants.BuildMode buildMode, String name, Transform3d botToCam, AprilTagFieldLayout fieldLayout) {
+  private PVApriltagIO getNewIO(
+      ShamLibConstants.BuildMode buildMode,
+      String name,
+      Transform3d botToCam,
+      AprilTagFieldLayout fieldLayout) {
     return switch (buildMode) {
       case REPLAY -> new PVApriltagIO() {};
       default -> new PVApriltagIOReal(name, botToCam, fieldLayout);

--- a/vision/PhotonVision/Apriltag/PVApriltagCam.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagCam.java
@@ -3,6 +3,7 @@ package frc.robot.ShamLib.vision.PhotonVision.Apriltag;
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.numbers.N1;
@@ -32,7 +33,7 @@ public class PVApriltagCam {
     Logger.processInputs(name, inputs);
   }
 
-  private Matrix<N3, N1> getXYThetaStdDev(Pose3d pose, int[] tagIds) {
+  private Matrix<N3, N1> getXYThetaStdDev(Pose2d pose, int[] tagIds) {
     double totalDistance = 0.0;
     int nonErrorTags = 0;
 
@@ -44,7 +45,7 @@ public class PVApriltagCam {
       var tagOnField = fieldLayout.getTagPose(tagId);
 
       if (tagOnField.isPresent()) {
-        totalDistance += pose.getTranslation().getDistance(tagOnField.get().getTranslation());
+        totalDistance += pose.getTranslation().getDistance(tagOnField.get().toPose2d().getTranslation());
         nonErrorTags++;
       }
     }
@@ -60,7 +61,7 @@ public class PVApriltagCam {
     return inputs.isConnected;
   }
 
-  public ArrayList<TimestampedPoseEstimator.TimestampedVisionUpdate> getAllEstimates() {
+  public TimestampedPoseEstimator.TimestampedVisionUpdate getAllEstimates() {
     double timestamp = inputs.timestamp;
     Pose3d[] estimates = inputs.cameraPoseEstimates;
     int[] ids = inputs.cameraPoseEstimateIDs;

--- a/vision/PhotonVision/Apriltag/PVApriltagIO.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagIO.java
@@ -3,6 +3,7 @@ package frc.robot.ShamLib.vision.PhotonVision.Apriltag;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import org.littletonrobotics.junction.AutoLog;
+import org.photonvision.PhotonPoseEstimator;
 
 public interface PVApriltagIO {
   @AutoLog
@@ -14,5 +15,11 @@ public interface PVApriltagIO {
     public boolean isConnected;
   }
 
+  public default void setEstimationStrategy(PhotonPoseEstimator.PoseStrategy strategy) {}
+
+  public default void setLastPose(Pose2d pose) {}
+
+  public default void setReferencePose(Pose2d pose) {}
+  public default void setMultiTagFallbackStrategy(PhotonPoseEstimator.PoseStrategy strategy) {}
   public default void updateInputs(PVApriltagInputs inputs) {}
 }

--- a/vision/PhotonVision/Apriltag/PVApriltagIO.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagIO.java
@@ -7,11 +7,11 @@ import org.photonvision.PhotonPoseEstimator;
 public interface PVApriltagIO {
   @AutoLog
   public class PVApriltagInputs {
-    public Pose2d poseEstimate;
-    public double timestamp;
-    public int[] targetsUsed;
+    public Pose2d poseEstimate = new Pose2d();
+    public double timestamp = 0.0;
+    public int[] targetsUsed = new int[0];
 
-    public boolean isConnected;
+    public boolean isConnected = false;
   }
 
   public default void setEstimationStrategy(PhotonPoseEstimator.PoseStrategy strategy) {}

--- a/vision/PhotonVision/Apriltag/PVApriltagIO.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagIO.java
@@ -1,7 +1,6 @@
 package frc.robot.ShamLib.vision.PhotonVision.Apriltag;
 
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Pose3d;
 import org.littletonrobotics.junction.AutoLog;
 import org.photonvision.PhotonPoseEstimator;
 
@@ -20,6 +19,8 @@ public interface PVApriltagIO {
   public default void setLastPose(Pose2d pose) {}
 
   public default void setReferencePose(Pose2d pose) {}
+
   public default void setMultiTagFallbackStrategy(PhotonPoseEstimator.PoseStrategy strategy) {}
+
   public default void updateInputs(PVApriltagInputs inputs) {}
 }

--- a/vision/PhotonVision/Apriltag/PVApriltagIO.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagIO.java
@@ -10,6 +10,8 @@ public interface PVApriltagIO {
     public Pose2d poseEstimate;
     public double timestamp;
     public int[] targetsUsed;
+
+    public boolean isConnected;
   }
 
   public default void updateInputs(PVApriltagInputs inputs) {}

--- a/vision/PhotonVision/Apriltag/PVApriltagIO.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagIO.java
@@ -1,23 +1,15 @@
 package frc.robot.ShamLib.vision.PhotonVision.Apriltag;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import org.littletonrobotics.junction.AutoLog;
 
 public interface PVApriltagIO {
   @AutoLog
   public class PVApriltagInputs {
-    public Pose3d[] cameraPoseEstimates = new Pose3d[0];
-    public int[] cameraPoseEstimateIDs = new int[0];
-    public Pose3d bestCameraPoseEstimate = new Pose3d();
-    public int bestTagID = 0;
-
-    public Pose3d multiTagPoseEstimate = new Pose3d();
-
-    public boolean hasTarget = false;
-
-    public double timestamp = 0.0;
-
-    public boolean isConnected = false;
+    public Pose2d poseEstimate;
+    public double timestamp;
+    public int[] targetsUsed;
   }
 
   public default void updateInputs(PVApriltagInputs inputs) {}

--- a/vision/PhotonVision/Apriltag/PVApriltagIOReal.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagIOReal.java
@@ -2,12 +2,9 @@ package frc.robot.ShamLib.vision.PhotonVision.Apriltag;
 
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Transform3d;
-import frc.robot.ShamLib.util.GeomUtil;
 import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonPoseEstimator;
-import org.photonvision.targeting.PhotonTrackedTarget;
 
 public class PVApriltagIOReal implements PVApriltagIO {
   private final PhotonCamera camera;
@@ -15,7 +12,9 @@ public class PVApriltagIOReal implements PVApriltagIO {
 
   public PVApriltagIOReal(String camName, Transform3d botToCamera, AprilTagFieldLayout layout) {
     camera = new PhotonCamera(camName);
-    poseEstimator = new PhotonPoseEstimator(layout, PhotonPoseEstimator.PoseStrategy.AVERAGE_BEST_TARGETS, camera, botToCamera);
+    poseEstimator =
+        new PhotonPoseEstimator(
+            layout, PhotonPoseEstimator.PoseStrategy.AVERAGE_BEST_TARGETS, camera, botToCamera);
   }
 
   @Override

--- a/vision/PhotonVision/Apriltag/PVApriltagIOReal.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagIOReal.java
@@ -32,5 +32,7 @@ public class PVApriltagIOReal implements PVApriltagIO {
 
       inputs.targetsUsed = tags;
     }
+
+    inputs.isConnected = camera.isConnected();
   }
 }

--- a/vision/PhotonVision/Apriltag/PVApriltagIOReal.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagIOReal.java
@@ -1,49 +1,36 @@
 package frc.robot.ShamLib.vision.PhotonVision.Apriltag;
 
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Transform3d;
 import frc.robot.ShamLib.util.GeomUtil;
 import org.photonvision.PhotonCamera;
+import org.photonvision.PhotonPoseEstimator;
 import org.photonvision.targeting.PhotonTrackedTarget;
 
 public class PVApriltagIOReal implements PVApriltagIO {
   private final PhotonCamera camera;
+  private final PhotonPoseEstimator poseEstimator;
 
-  public PVApriltagIOReal(String camName) {
+  public PVApriltagIOReal(String camName, Transform3d botToCamera, AprilTagFieldLayout layout) {
     camera = new PhotonCamera(camName);
+    poseEstimator = new PhotonPoseEstimator(layout, PhotonPoseEstimator.PoseStrategy.AVERAGE_BEST_TARGETS, camera, botToCamera);
   }
 
   @Override
   public void updateInputs(PVApriltagInputs inputs) {
-    var latest = camera.getLatestResult();
+    var estimate = poseEstimator.update();
+    if (estimate.isPresent()) {
+      inputs.poseEstimate = estimate.get().estimatedPose.toPose2d();
+      inputs.timestamp = estimate.get().timestampSeconds;
+      int[] tags = new int[estimate.get().targetsUsed.size()];
 
-    Pose3d[] poses = new Pose3d[latest.targets.size()];
-    int[] ids = new int[latest.targets.size()];
+      for (int i = 0; i < tags.length; i++) {
+        tags[i] = estimate.get().targetsUsed.get(i).getFiducialId();
+      }
 
-    for (int i = 0; i < latest.targets.size(); i++) {
-      PhotonTrackedTarget target = latest.targets.get(i);
-      poses[i] = GeomUtil.transform3dToPose3d(target.getBestCameraToTarget());
-      ids[i] = target.getFiducialId();
+      inputs.targetsUsed = tags;
     }
-
-    inputs.timestamp = latest.getTimestampSeconds();
-
-    inputs.cameraPoseEstimates = poses;
-    inputs.cameraPoseEstimateIDs = ids;
-
-    if (latest.hasTargets()) {
-      inputs.bestCameraPoseEstimate =
-          GeomUtil.transform3dToPose3d(latest.getBestTarget().getBestCameraToTarget());
-      inputs.bestTagID = latest.getBestTarget().getFiducialId();
-
-      inputs.multiTagPoseEstimate =
-          GeomUtil.transform3dToPose3d(latest.getMultiTagResult().estimatedPose.best);
-
-      inputs.hasTarget = true;
-    } else {
-      inputs.hasTarget = false;
-      inputs.bestTagID = -1;
-    }
-
-    inputs.isConnected = camera.isConnected();
   }
 }

--- a/vision/PhotonVision/Apriltag/PVApriltagIOReal.java
+++ b/vision/PhotonVision/Apriltag/PVApriltagIOReal.java
@@ -19,6 +19,26 @@ public class PVApriltagIOReal implements PVApriltagIO {
   }
 
   @Override
+  public void setEstimationStrategy(PhotonPoseEstimator.PoseStrategy strategy) {
+    poseEstimator.setPrimaryStrategy(strategy);
+  }
+
+  @Override
+  public void setLastPose(Pose2d pose) {
+    poseEstimator.setLastPose(pose);
+  }
+
+  @Override
+  public void setMultiTagFallbackStrategy(PhotonPoseEstimator.PoseStrategy strategy) {
+    poseEstimator.setMultiTagFallbackStrategy(strategy);
+  }
+
+  @Override
+  public void setReferencePose(Pose2d pose) {
+    poseEstimator.setReferencePose(pose);
+  }
+
+  @Override
   public void updateInputs(PVApriltagInputs inputs) {
     var estimate = poseEstimator.update();
     if (estimate.isPresent()) {


### PR DESCRIPTION
- use photonvision pose estimator for pose estimation
- allow swerve drive to accept timestamped vision data when using non-6328 pose estimator